### PR TITLE
Show property reviews on property detail page

### DIFF
--- a/src/app/properties/properties.module.ts
+++ b/src/app/properties/properties.module.ts
@@ -18,6 +18,7 @@ import { MyPropertiesComponent } from './my-properties/my-properties.component';
 import { PropertyEditComponent } from './property-edit/property-edit.component';
 import { PropertyCreatedDialogComponent } from './property-created-dialog/property-created-dialog.component';
 import { PropertyUpdatedDialogComponent } from './property-updated-dialog/property-updated-dialog.component';
+import { ReviewCardComponent } from './review-card/review-card.component';
 
 
 @NgModule({
@@ -33,7 +34,8 @@ import { PropertyUpdatedDialogComponent } from './property-updated-dialog/proper
     MyPropertiesComponent,
     PropertyEditComponent,
     PropertyCreatedDialogComponent,
-    PropertyUpdatedDialogComponent
+    PropertyUpdatedDialogComponent,
+    ReviewCardComponent
   ],
   imports: [
     SharedModule,

--- a/src/app/properties/property-detail/property-detail.component.html
+++ b/src/app/properties/property-detail/property-detail.component.html
@@ -48,4 +48,5 @@
       </div>
     </form>
   </div>
+  <app-review-card *ngFor="let review of property?.reviews" [review]="review"></app-review-card>
 </div>

--- a/src/app/properties/review-card/review-card.component.css
+++ b/src/app/properties/review-card/review-card.component.css
@@ -61,7 +61,7 @@
 .rating {
   margin-right: 3em;
 }
-.rating, .report {
+.rating, .report, .delete {
   display: flex;
   align-items: center;
 }

--- a/src/app/properties/review-card/review-card.component.css
+++ b/src/app/properties/review-card/review-card.component.css
@@ -1,0 +1,75 @@
+.review-card {
+  padding-top: 2em;
+  padding-bottom: 1em;
+  padding-right: 2em;
+  padding-left: 2em;
+  margin: 0.5em 2em;
+  background-color: #2d2d2d;
+  border-radius: 20px;
+}
+
+.circular-image {
+  width: 4em;
+  height: 4em;
+  border: 2px solid #00b3b3;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.review-header {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.reviewer-and-time {
+  display: flex;
+}
+
+.reviewer-name-and-time {
+  display: inline-flex;
+  flex-direction: column;
+  justify-content: center;
+  margin-left: 1em;
+}
+
+.reviewer-name {
+  margin-bottom: 0.3em;
+  font-family: rubik-regular;
+  font-size: 22px;
+}
+
+.review-time {
+  margin-bottom: 0;
+  color: #00b3b3;
+}
+
+.review-content {
+  margin-left: 3em;
+  margin-right: 3em;
+  margin-top: 1.5em;
+  text-align: justify;
+  font-family: rubik-regular;
+}
+
+.review-rating {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+}
+
+.rating {
+  margin-right: 3em;
+}
+.rating, .report {
+  display: flex;
+  align-items: center;
+}
+
+.report > button {
+    color: red;
+}
+
+mat-icon {
+  margin-right: 0.2em;
+}

--- a/src/app/properties/review-card/review-card.component.html
+++ b/src/app/properties/review-card/review-card.component.html
@@ -1,0 +1,28 @@
+<div class="review-card">
+    <div class="review-header">
+        <div class="reviewer-and-time">
+            <img src="assets/jake-gyllenhaal.jpg" class="circular-image">
+            <div class="reviewer-name-and-time">
+                <h3 class="reviewer-name">Jake Gyllenhaal</h3>
+                <p class="review-time">October 24, 2023</p>
+            </div>
+        </div>
+        <div class="review-rating">
+            <div class="rating">
+                <mat-icon>star</mat-icon>
+                <span>4.5</span>
+            </div>
+            <div class="report">
+                <button mat-button>
+                    <mat-icon>flag</mat-icon>
+                    <span>Report</span>
+                </button>
+            </div>
+        </div>
+    </div>
+    <p class="review-content">
+        The missile knows where it is at all times. It knows this because it knows where it isn't. By subtracting where it is from where it isn't, or where it isn't from where it is (whichever is greater), it obtains a difference, or deviation. The guidance subsystem uses deviations to generate corrective commands to drive the missile from a position where it is to a position where it isn't, and arriving at a position where it wasn't, it now is. Consequently, the position where it is, is now the position that it wasn't, and it follows that the position that it was, is now the position that it isn't.
+        In the event that the position that it is in is not the position that it wasn't, the system has acquired a variation, the variation being the difference between where the missile is, and where it wasn't. If variation is considered to be a significant factor, it too may be corrected by the GEA. However, the missile must also know where it was.
+        The missile guidance computer scenario works as follows. Because a variation has modified some of the information the missile has obtained, it is not sure just where it is. However, it is sure where it isn't, within reason, and it knows where it was. It now subtracts where it should be from where it wasn't, or vice-versa, and by differentiating this from the algebraic sum of where it shouldn't be, and where it was, it is able to obtain the deviation and its variation, which is called error.
+    </p>
+</div>

--- a/src/app/properties/review-card/review-card.component.html
+++ b/src/app/properties/review-card/review-card.component.html
@@ -3,14 +3,14 @@
         <div class="reviewer-and-time">
             <img src="assets/jake-gyllenhaal.jpg" class="circular-image">
             <div class="reviewer-name-and-time">
-                <h3 class="reviewer-name">Jake Gyllenhaal</h3>
-                <p class="review-time">October 24, 2023</p>
+                <h3 class="reviewer-name">{{review.author}}</h3>
+                <p class="review-time">{{review.date | date:'longDate'}}</p> 
             </div>
         </div>
         <div class="review-rating">
             <div class="rating">
                 <mat-icon>star</mat-icon>
-                <span>4.5</span>
+                <span>{{review.rating}}</span>
             </div>
             <div class="report">
                 <button mat-button>
@@ -21,8 +21,6 @@
         </div>
     </div>
     <p class="review-content">
-        The missile knows where it is at all times. It knows this because it knows where it isn't. By subtracting where it is from where it isn't, or where it isn't from where it is (whichever is greater), it obtains a difference, or deviation. The guidance subsystem uses deviations to generate corrective commands to drive the missile from a position where it is to a position where it isn't, and arriving at a position where it wasn't, it now is. Consequently, the position where it is, is now the position that it wasn't, and it follows that the position that it was, is now the position that it isn't.
-        In the event that the position that it is in is not the position that it wasn't, the system has acquired a variation, the variation being the difference between where the missile is, and where it wasn't. If variation is considered to be a significant factor, it too may be corrected by the GEA. However, the missile must also know where it was.
-        The missile guidance computer scenario works as follows. Because a variation has modified some of the information the missile has obtained, it is not sure just where it is. However, it is sure where it isn't, within reason, and it knows where it was. It now subtracts where it should be from where it wasn't, or vice-versa, and by differentiating this from the algebraic sum of where it shouldn't be, and where it was, it is able to obtain the deviation and its variation, which is called error.
+        {{review.description}}
     </p>
 </div>

--- a/src/app/properties/review-card/review-card.component.html
+++ b/src/app/properties/review-card/review-card.component.html
@@ -12,8 +12,8 @@
                 <mat-icon>star</mat-icon>
                 <span>{{review.rating}}</span>
             </div>
-            <div class="report">
-                <button mat-button>
+            <div class="report" *ngIf="review.authorId != accountService.getAccountId()">
+                <button mat-button (click)="onReport()">
                     <mat-icon>flag</mat-icon>
                     <span>Report</span>
                 </button>

--- a/src/app/properties/review-card/review-card.component.html
+++ b/src/app/properties/review-card/review-card.component.html
@@ -18,6 +18,11 @@
                     <span>Report</span>
                 </button>
             </div>
+            <div class="delete">
+                <button mat-button (click)="onDelete()">
+                    <mat-icon>delete</mat-icon>
+                </button>
+            </div>
         </div>
     </div>
     <p class="review-content">

--- a/src/app/properties/review-card/review-card.component.html
+++ b/src/app/properties/review-card/review-card.component.html
@@ -18,9 +18,10 @@
                     <span>Report</span>
                 </button>
             </div>
-            <div class="delete">
+            <div class="delete" *ngIf="review.authorId == accountService.getAccountId()">
                 <button mat-button (click)="onDelete()">
                     <mat-icon>delete</mat-icon>
+                    <span>Delete</span>
                 </button>
             </div>
         </div>

--- a/src/app/properties/review-card/review-card.component.spec.ts
+++ b/src/app/properties/review-card/review-card.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ReviewCardComponent } from './review-card.component';
+
+describe('ReviewCardComponent', () => {
+  let component: ReviewCardComponent;
+  let fixture: ComponentFixture<ReviewCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ReviewCardComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(ReviewCardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/properties/review-card/review-card.component.ts
+++ b/src/app/properties/review-card/review-card.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { Review } from '../../shared/models/review.model';
+import { AccountService } from '../../account/account.service';
 
 @Component({
   selector: 'app-review-card',
@@ -9,6 +10,13 @@ import { Review } from '../../shared/models/review.model';
 export class ReviewCardComponent {
   @Input() review: Review;
   @Output() deleted: EventEmitter<number> = new EventEmitter<number>();
+  @Output() reported: EventEmitter<number> = new EventEmitter<number>();
+
+  accountService: AccountService;
+
+  constructor(accountService: AccountService) {
+    this.accountService = accountService;
+  }
 
   onDelete(): void {
     this.deleted.emit(this.review.id);

--- a/src/app/properties/review-card/review-card.component.ts
+++ b/src/app/properties/review-card/review-card.component.ts
@@ -21,4 +21,8 @@ export class ReviewCardComponent {
   onDelete(): void {
     this.deleted.emit(this.review.id);
   }
+
+  onReport(): void {
+    this.reported.emit(this.review.id);
+  }
 }

--- a/src/app/properties/review-card/review-card.component.ts
+++ b/src/app/properties/review-card/review-card.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { Review } from '../../shared/models/review.model';
 
 @Component({
@@ -8,4 +8,9 @@ import { Review } from '../../shared/models/review.model';
 })
 export class ReviewCardComponent {
   @Input() review: Review;
+  @Output() deleted: EventEmitter<number> = new EventEmitter<number>();
+
+  onDelete(): void {
+    this.deleted.emit(this.review.id);
+  }
 }

--- a/src/app/properties/review-card/review-card.component.ts
+++ b/src/app/properties/review-card/review-card.component.ts
@@ -1,0 +1,11 @@
+import { Component, Input } from '@angular/core';
+import { Review } from '../../shared/models/review.model';
+
+@Component({
+  selector: 'app-review-card',
+  templateUrl: './review-card.component.html',
+  styleUrl: './review-card.component.css'
+})
+export class ReviewCardComponent {
+  @Input() review: Review;
+}

--- a/src/app/shared/models/property.model.ts
+++ b/src/app/shared/models/property.model.ts
@@ -2,6 +2,7 @@ import Amenity from "./amenity.model";
 import Location from "./location.model";
 import PropertyAvailabilityEntry from "./property-availability-entry.model";
 import PropertyRequest from "./property-request.model";
+import { Review } from "./review.model";
 
 export interface Property {
   id: number;
@@ -25,6 +26,7 @@ export interface Property {
   amenities: Amenity[];
   maxGuests: number;
   hostId: number;
+  reviews?: Review[];
 }
 
 export enum PropertyType {

--- a/src/app/shared/models/review.model.ts
+++ b/src/app/shared/models/review.model.ts
@@ -1,0 +1,5 @@
+export interface Review {
+    rating: number;
+    description: string;
+    date: Date;
+}

--- a/src/app/shared/models/review.model.ts
+++ b/src/app/shared/models/review.model.ts
@@ -2,4 +2,7 @@ export interface Review {
     rating: number;
     description: string;
     date: Date;
+    authorId: number;
+    author: string;
+    id?: number;
 }


### PR DESCRIPTION
This PR adds reviews to the property detail page, which are displayed as cards at the bottom of the page.
The delete button is not shown if a review is not by the current user. Additionally, the current user cannot report themselves.
Screenshot of the changes:
![image](https://github.com/tinylunark/lunark-front/assets/40830508/8f810cb4-c7f3-48dd-9cc0-7153f2f8f66f)

