### PR TITLE
Restrict booking form visibility

### DIFF
--- a/src/app/properties/property-detail/property-detail.component.html
+++ b/src/app/properties/property-detail/property-detail.component.html
@@ -23,7 +23,7 @@
       <p>{{ property?.description }}</p>
     </div>
 
-    <form fxLayout="column" fxLayoutAlign="start stretch" *ngIf="this.getRole() !== 'unregistered'"
+    <form fxLayout="column" fxLayoutAlign="start stretch" *ngIf="this.getRole() === 'GUEST'"
           [formGroup]="this.reservationFormGroup" (ngSubmit)="createReservation()">
       <mat-form-field appearance="outline">
         <mat-label>Date range</mat-label>


### PR DESCRIPTION
This PR fixes the bug when other roles can see the property booking form. Now, only the guest can see the booking form.