### PR TITLE
Make app usable after session has expired

### DIFF
--- a/src/app/http-interceptors/unauthorized.interceptor.ts
+++ b/src/app/http-interceptors/unauthorized.interceptor.ts
@@ -1,9 +1,9 @@
 import { Injectable } from '@angular/core';
 import {
-  HttpEvent, HttpInterceptor, HttpHandler, HttpRequest, HttpResponse, HttpErrorResponse
+  HttpEvent, HttpInterceptor, HttpHandler, HttpRequest, HttpErrorResponse
 } from '@angular/common/http';
 
-import {catchError, Observable, tap, throwError} from 'rxjs';
+import {catchError, Observable, throwError} from 'rxjs';
 import {Router} from "@angular/router";
 
 /** Redirect to session expired screen if not authorized */
@@ -17,6 +17,7 @@ export class UnauthorizedInterceptor implements HttpInterceptor {
     return next.handle(req).pipe(
       catchError((error: HttpErrorResponse) => {
         if (error.status === 401 && !req.headers.has('skip')) {
+          localStorage.removeItem('lunark-user');
           this.router.navigate(['/session-expired']);
         }
         return throwError(() => error)


### PR DESCRIPTION
Previously, any action after the session expired has appeared would redirect the user back to that screen.
This PR fixes this by clearing the authentication token from local storage in `UnauthorizedInterceptor` so it's not sent anymore and so that the navbar changes to one of an unregistered user.