### PR TITLE
Add validations to the content of a review

### DIFF
--- a/src/app/reviews/review-dialog/review-dialog.component.ts
+++ b/src/app/reviews/review-dialog/review-dialog.component.ts
@@ -10,8 +10,8 @@ import { MatDialogRef } from '@angular/material/dialog';
 export class ReviewDialogComponent {
 
   reviewForm: FormGroup = new FormGroup({
-    rating: new FormControl('', Validators.required),
-    description: new FormControl('', Validators.required),
+    rating: new FormControl('', [Validators.required, Validators.min(1), Validators.max(5)]),
+    description: new FormControl('', [Validators.required, Validators.pattern('[a-zA-Z0-9 \\.!\\?]+')]),
   });
   rating: number = 0;
   constructor(public dialogRef: MatDialogRef<ReviewDialogComponent>) { }


### PR DESCRIPTION
This PR adds validators to the form in `ReviewDialogComopnent` that check if the text of a review contains only allowed characters and whether a rating is between 1 and 5.