### PR TITLE
Remove extra /api from host profile picture link on property detail page

### DIFF
--- a/src/app/account/profile-image/profile-image.component.ts
+++ b/src/app/account/profile-image/profile-image.component.ts
@@ -12,7 +12,7 @@ export class ProfileImageComponent implements OnInit {
   profileImageURL?: string;
 
   ngOnInit(): void {
-      this.profileImageURL = `${environment.apiHost}/api/${ApiPaths.Profile}/${this.id}/profile-image`;
+      this.profileImageURL = `${environment.apiHost}/${ApiPaths.Profile}/${this.id}/profile-image`;
   }
 
 }


### PR DESCRIPTION
This PR fixes a typo which led to the host's profile picture never being displayed on the property detail page.