### PR TITLE
Allow manual input of street city country

### DIFF
--- a/src/app/properties/property-edit/property-edit.component.css
+++ b/src/app/properties/property-edit/property-edit.component.css
@@ -6,6 +6,10 @@ width: 50em;
   margin-bottom: 2em;
 }
 
+.selectedComponentContainer:has(app-location) {
+  flex-direction: column;
+}
+
 app-availability-pricing {
     display: flex;
     justify-content: center;

--- a/src/app/properties/property-edit/property-edit.component.html
+++ b/src/app/properties/property-edit/property-edit.component.html
@@ -12,6 +12,63 @@
 
   <div *ngIf="selectedMenuItem === 'location'" class="selectedComponentContainer">
     <app-location (change)="onChange()" [(latitude)]="property.latitude" [(longitude)]="property.longitude" [(address)]="property.address.street" [(city)]="property.address.city" [(country)]="property.address.country" ></app-location>
+      <div class="field-container address-field">
+        <p>Street</p>
+        <mat-form-field
+          class="input-field"
+          appearance="outline"
+          id="street-field"
+        >
+          <mat-label>Street</mat-label>
+          <input
+            matInput
+            type="text"
+            name="street"
+            [(ngModel)]="property.address.street"
+            pattern="^[^<>%$]*$"
+            required
+            id="street-input"
+          />
+        </mat-form-field>
+      </div>
+      <div class="field-container address-field">
+        <p>City</p>
+        <mat-form-field
+          class="input-field"
+          appearance="outline"
+          id="city-field"
+        >
+          <mat-label>City</mat-label>
+          <input
+            matInput
+            type="text"
+            name="city"
+            [(ngModel)]="property.address.city"
+            pattern="^[^<>%$]*$"
+            required
+            id="city-input"
+          />
+        </mat-form-field>
+      </div>
+      <div class="field-container address-field">
+        <p>Country</p>
+        <mat-form-field
+          class="input-field"
+          appearance="outline"
+          id="country-field"
+        >
+          <mat-label>Country</mat-label>
+          <input
+            matInput
+            type="text"
+            name="street"
+            [(ngModel)]="property.address.country"
+            pattern="^[^<>%$]*$"
+            required
+            id="country-input"
+          />
+        </mat-form-field>
+      </div>
   </div>
 
   <div *ngIf="selectedMenuItem === 'amenities'" class="selectedComponentContainer">

--- a/src/app/properties/property-edit/property-edit.component.ts
+++ b/src/app/properties/property-edit/property-edit.component.ts
@@ -9,6 +9,7 @@ import { PropertyUpdatedDialogComponent } from '../property-updated-dialog/prope
 import { Observable } from 'rxjs';
 import PropertyAvailabilityEntry from '../../shared/models/property-availability-entry.model';
 import PropertyRequest from '../../shared/models/property-request.model';
+import { SharedService } from '../../shared/shared.service';
 
 
 
@@ -50,7 +51,8 @@ export class PropertyEditComponent implements OnInit {
     private propertyService: PropertyService,
     private route: ActivatedRoute,
     private router: Router,
-    private matDialog: MatDialog
+    private matDialog: MatDialog,
+    private sharedService: SharedService
   ) { }
 
   ngOnInit(): void {
@@ -125,6 +127,12 @@ export class PropertyEditComponent implements OnInit {
       },
       error: (error) => {
         console.log(error);
+        if (error.status === 400) {
+            this.sharedService.openSnack('One of the fields you have edited is not valid.');
+        }
+        if (error.status === 409) {
+            this.sharedService.openSnack('You have closed the property for a date on which there is a reservation.');
+        }
       },
     });
   }

--- a/src/app/properties/property-management/description/description.component.ts
+++ b/src/app/properties/property-management/description/description.component.ts
@@ -8,7 +8,7 @@ import { FormControl, FormGroup, Validators } from '@angular/forms';
 })
 export class DescriptionComponent {
   infoForm = new FormGroup({
-    description: new FormControl('', [Validators.required]),
+    description: new FormControl('', [Validators.required, Validators.pattern('[a-zA-Z0-9 \.!\?\'\"]+')]),
   });
 
   @Input()

--- a/src/app/properties/property-new/property-new.component.css
+++ b/src/app/properties/property-new/property-new.component.css
@@ -87,3 +87,7 @@ app-availability-table {
     margin-top: 2em;
     width: 10%;
 }
+
+.address-field mat-form-field {
+    width: 30em;
+}

--- a/src/app/properties/property-new/property-new.component.html
+++ b/src/app/properties/property-new/property-new.component.html
@@ -22,6 +22,66 @@
         [(city)]="property.address.city"
         [(country)]="property.address.country"
       ></app-location>
+      <div class="field-container address-field">
+        <p>Street</p>
+        <mat-form-field
+          class="input-field"
+          appearance="outline"
+          id="street-field"
+        >
+          <mat-label>Street</mat-label>
+          <input
+            matInput
+            type="text"
+            name="street"
+            [(ngModel)]="property.address.street"
+            (change)="checkForStepCompletions()"
+            pattern="^[^<>%$]*$"
+            required
+            id="street-input"
+          />
+        </mat-form-field>
+      </div>
+      <div class="field-container address-field">
+        <p>City</p>
+        <mat-form-field
+          class="input-field"
+          appearance="outline"
+          id="city-field"
+        >
+          <mat-label>City</mat-label>
+          <input
+            matInput
+            type="text"
+            name="city"
+            [(ngModel)]="property.address.city"
+            (change)="checkForStepCompletions()"
+            pattern="^[^<>%$]*$"
+            required
+            id="city-input"
+          />
+        </mat-form-field>
+      </div>
+      <div class="field-container address-field">
+        <p>Country</p>
+        <mat-form-field
+          class="input-field"
+          appearance="outline"
+          id="country-field"
+        >
+          <mat-label>Country</mat-label>
+          <input
+            matInput
+            type="text"
+            name="street"
+            [(ngModel)]="property.address.country"
+            (change)="checkForStepCompletions()"
+            pattern="^[^<>%$]*$"
+            required
+            id="country-input"
+          />
+        </mat-form-field>
+      </div>
       <div class="stepper-button-container">
         <button mat-button matStepperPrevious>Previous</button>
         <button mat-button matStepperNext>Next</button>

--- a/src/app/properties/property-new/property-new.component.ts
+++ b/src/app/properties/property-new/property-new.component.ts
@@ -20,6 +20,9 @@ export class PropertyNewComponent {
   step2Completed = false;
   step3Completed = false;
   propertyNameControl: FormControl = new FormControl('', Validators.required);
+  streetControl: FormControl = new FormControl('', [Validators.required, Validators.pattern('^[^<>%$]*$')]);
+  cityControl: FormControl = new FormControl('', [Validators.required, Validators.pattern('^[^<>%$]*$')]);
+  countryControl: FormControl = new FormControl('', [Validators.required, Validators.pattern('^[^<>%$]*$')]);
 
   constructor(
     private propertyService: PropertyService,
@@ -59,10 +62,14 @@ export class PropertyNewComponent {
   }
 
   private isLocationValid(): boolean {
+    console.log(this.property.address);
     return (
       this.property.address.street !== '' &&
       this.property.address.city !== '' &&
       this.property.address.country !== '' &&
+      this.property.address.street.match(/^[^<>%$]*$/) !== null &&
+      this.property.address.city.match(/^[^<>%$]*$/) !== null &&
+      this.property.address.country.match(/^[^<>%$]*$/) !== null &&
       this.property.latitude !== null &&
       this.property.longitude !== null
     );
@@ -87,6 +94,9 @@ export class PropertyNewComponent {
 
   onChange(): void {
     this.property.name = this.propertyNameControl.value;
+    this.streetControl.setValue(this.property.address.street);
+    this.cityControl.setValue(this.property.address.city);
+    this.countryControl.setValue(this.property.address.country);
     this.checkForStepCompletions();
     console.log(this.property);
   }

--- a/src/app/report-dialog/report-dialog.component.ts
+++ b/src/app/report-dialog/report-dialog.component.ts
@@ -11,7 +11,7 @@ import { SharedService } from '../shared/shared.service';
 })
 export class ReportDialogComponent {
   reportForm: FormGroup = new FormGroup({
-    reason: new FormControl('', [Validators.required]),
+    reason: new FormControl('', [Validators.required, Validators.pattern('[a-zA-Z0-9 \.!\?\'\"]+')]),
   });
   reportedUserId: number | null = null;
   title: string = "Report host";

--- a/src/app/reviews/review-dialog/review-dialog.component.ts
+++ b/src/app/reviews/review-dialog/review-dialog.component.ts
@@ -11,7 +11,7 @@ export class ReviewDialogComponent {
 
   reviewForm: FormGroup = new FormGroup({
     rating: new FormControl('', [Validators.required, Validators.min(1), Validators.max(5)]),
-    description: new FormControl('', [Validators.required, Validators.pattern('[a-zA-Z0-9 \\.!\\?]+')]),
+    description: new FormControl('', [Validators.required, Validators.pattern('[a-zA-Z0-9 \.!\?\'\"]+')]),
   });
   rating: number = 0;
   constructor(public dialogRef: MatDialogRef<ReviewDialogComponent>) { }


### PR DESCRIPTION
This PR enables hosts to manually input the address of their property so they can correct the automatically filled one based on coordinates or in case Nominatim is down and the automatic population of those fields does not work.
This PR also adds:

- Meaningful error messages when editing a property
- Users can input apostrophes and quotes in longer texts (depends on https://github.com/tinylunark/lunark-back/pull/102)
